### PR TITLE
Add a -headless flag (for dev mode)

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,12 +41,13 @@ import (
 )
 
 var (
-	nItemsFlag  = flag.Int("n", -1, "number of items to download. If negative, get them all.")
-	devFlag     = flag.Bool("dev", false, "dev mode. we reuse the same session dir (/tmp/gphotos-cdp), so we don't have to auth at every run.")
-	dlDirFlag   = flag.String("dldir", "", "where to write the downloads. defaults to $HOME/Downloads/gphotos-cdp.")
-	startFlag   = flag.String("start", "", "skip all photos until this location is reached. for debugging.")
-	runFlag     = flag.String("run", "", "the program to run on each downloaded item, right after it is dowloaded. It is also the responsibility of that program to remove the downloaded item, if desired.")
-	verboseFlag = flag.Bool("v", false, "be verbose")
+	nItemsFlag   = flag.Int("n", -1, "number of items to download. If negative, get them all.")
+	devFlag      = flag.Bool("dev", false, "dev mode. we reuse the same session dir (/tmp/gphotos-cdp), so we don't have to auth at every run.")
+	dlDirFlag    = flag.String("dldir", "", "where to write the downloads. defaults to $HOME/Downloads/gphotos-cdp.")
+	startFlag    = flag.String("start", "", "skip all photos until this location is reached. for debugging.")
+	runFlag      = flag.String("run", "", "the program to run on each downloaded item, right after it is dowloaded. It is also the responsibility of that program to remove the downloaded item, if desired.")
+	verboseFlag  = flag.Bool("v", false, "be verbose")
+	headlessFlag = flag.Bool("headless", false, "Start chrome browser in headless mode (cannot do authentication this way).")
 )
 
 var tick = 500 * time.Millisecond
@@ -150,34 +151,21 @@ func NewSession() (*Session, error) {
 }
 
 func (s *Session) NewContext() (context.Context, context.CancelFunc) {
-	ctx, cancel := chromedp.NewExecAllocator(context.Background(),
-		chromedp.NoFirstRun,
-		chromedp.NoDefaultBrowserCheck,
+	// Let's use as a base for allocator options (It implies Headless)
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.DisableGPU,
 		chromedp.UserDataDir(s.profileDir),
-
-		chromedp.Flag("disable-background-networking", true),
-		chromedp.Flag("enable-features", "NetworkService,NetworkServiceInProcess"),
-		chromedp.Flag("disable-background-timer-throttling", true),
-		chromedp.Flag("disable-backgrounding-occluded-windows", true),
-		chromedp.Flag("disable-breakpad", true),
-		chromedp.Flag("disable-client-side-phishing-detection", true),
-		chromedp.Flag("disable-default-apps", true),
-		chromedp.Flag("disable-dev-shm-usage", true),
-		chromedp.Flag("disable-extensions", true),
-		chromedp.Flag("disable-features", "site-per-process,TranslateUI,BlinkGenPropertyTrees"),
-		chromedp.Flag("disable-hang-monitor", true),
-		chromedp.Flag("disable-ipc-flooding-protection", true),
-		chromedp.Flag("disable-popup-blocking", true),
-		chromedp.Flag("disable-prompt-on-repost", true),
-		chromedp.Flag("disable-renderer-backgrounding", true),
-		chromedp.Flag("disable-sync", true),
-		chromedp.Flag("force-color-profile", "srgb"),
-		chromedp.Flag("metrics-recording-only", true),
-		chromedp.Flag("safebrowsing-disable-auto-update", true),
-		chromedp.Flag("enable-automation", true),
-		chromedp.Flag("password-store", "basic"),
-		chromedp.Flag("use-mock-keychain", true),
 	)
+
+	if !*headlessFlag {
+		// undo the three opts in chromedp.Headless() which is included in DefaultExecAllocatorOptions
+		opts = append(opts, chromedp.Flag("headless", false))
+		opts = append(opts, chromedp.Flag("hide-scrollbars", false))
+		opts = append(opts, chromedp.Flag("mute-audio", false))
+		// undo DisableGPU from above
+		opts = append(opts, chromedp.Flag("disable-gpu", false))
+	}
+	ctx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
 	s.parentContext = ctx
 	s.parentCancel = cancel
 	ctx, cancel = chromedp.NewContext(s.parentContext)
@@ -272,6 +260,7 @@ func (s *Session) firstNav(ctx context.Context) error {
 	if err := navToEnd(ctx); err != nil {
 		return err
 	}
+	log.Printf("Nav to end- DONE")
 
 	if err := navToLast(ctx); err != nil {
 		return err
@@ -332,9 +321,11 @@ func navToEnd(ctx context.Context) error {
 // new page. It then sends the right arrow key event until we've reached the very
 // last item.
 func navToLast(ctx context.Context) error {
+	log.Printf("Nav to last- START")
 	var location, prevLocation string
 	ready := false
 	for {
+		log.Printf("Nav to last...")
 		chromedp.KeyEvent(kb.ArrowRight).Do(ctx)
 		time.Sleep(tick)
 		if !ready {

--- a/main.go
+++ b/main.go
@@ -58,41 +58,35 @@ func main() {
 		return
 	}
 	if !*devFlag && *startFlag != "" {
-		log.Print("-start only allowed in dev mode")
-		return
+		log.Fatal("-start only allowed in dev mode")
 	}
 	if !*devFlag && *headlessFlag {
-		log.Print("-headless only allowed in dev mode")
-		return
+		log.Fatal("-headless only allowed in dev mode")
 	}
 	s, err := NewSession()
 	if err != nil {
-		log.Print(err)
-		return
+		log.Fatal(err)
 	}
 	defer s.Shutdown()
 
 	log.Printf("Session Dir: %v", s.profileDir)
 
 	if err := s.cleanDlDir(); err != nil {
-		log.Print(err)
-		return
+		log.Fatal(err)
 	}
 
 	ctx, cancel := s.NewContext()
 	defer cancel()
 
 	if err := s.login(ctx); err != nil {
-		log.Print(err)
-		return
+		log.Fatal(err)
 	}
 
 	if err := chromedp.Run(ctx,
 		chromedp.ActionFunc(s.firstNav),
 		chromedp.ActionFunc(s.navN(*nItemsFlag)),
 	); err != nil {
-		log.Print(err)
-		return
+		log.Fatal(err)
 	}
 	fmt.Println("OK")
 }
@@ -230,7 +224,7 @@ func (s *Session) login(ctx context.Context) error {
 					return nil
 				}
 				if *headlessFlag {
-					return errors.New("You cannot authenticate in -headless mode")
+					return errors.New("authentication not possible in -headless mode")
 				}
 				if *verboseFlag {
 					log.Printf("Not yet authenticated, at: %v", location)
@@ -372,9 +366,7 @@ func doRun(filePath string) error {
 // navLeft navigates to the next item to the left
 func navLeft(ctx context.Context) error {
 	chromedp.KeyEvent(kb.ArrowLeft).Do(ctx)
-	// Could wait for the location to change instead of this Sleep.
-	time.Sleep(200 * time.Millisecond)
-
+	chromedp.WaitReady("body", chromedp.ByQuery)
 	return nil
 }
 


### PR DESCRIPTION
- Add a headless flag to operate Chrome in headless mode (no window
  - Prevent it's usage in non-dev mode
  - Exit with error if we need to authenticate.
- Used `chromedp.DefaultExecAllocatorOptions` as a base which has all the settings we require, and revert the three specific options implied by the included `chromedp.Headless()`