### PR TITLE
Better slow connection support

### DIFF
--- a/main.go
+++ b/main.go
@@ -359,7 +359,7 @@ func navToEnd(ctx context.Context) error {
 			break
 		}
 		previousScr = scr
-		time.Sleep(tick)
+		time.Sleep(10*tick)
 	}
 
 	if *verboseFlag {
@@ -417,6 +417,9 @@ func doRun(filePath string) error {
 
 // navLeft navigates to the next item to the left
 func navLeft(ctx context.Context) error {
+	var res []string
+	chromedp.EvaluateAsDevTools(`window.resize();`, &res)
+	time.Sleep(tick)
 	muNavWaiting.Lock()
 	listenEvents = true
 	muNavWaiting.Unlock()


### PR DESCRIPTION
Issue
Slow internet speeds and slow page loads prevent navigating to end correctly without resulting in many many navRight steps. Additionally impacts navLeft when this doesn’t load in a timely manner (or possibly portrait photos TBC)

Background 
The page down/end detection done off screen shots when the unpopulated gray tiles match again and again doesn’t recognise its not reached the end. 

Implementation 
By waiting slightly longer between pagination it at least loads the gray boxes to correct proportions and identifies the page has not reached end. Also adding a nudge the window.resize() before attempting click left better tolerate slow page loads with large images or videos on slow connections. 

Fix for issue #33 and possibly #19